### PR TITLE
Added health checks

### DIFF
--- a/Building33MockApi/Building33MockApi.csproj
+++ b/Building33MockApi/Building33MockApi.csproj
@@ -16,6 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
     <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.62.0" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" />

--- a/Building33MockApi/Program.cs
+++ b/Building33MockApi/Program.cs
@@ -1,4 +1,6 @@
 using Building33MockApi.Services;
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Serilog;
 using StackExchange.Redis;
 
@@ -37,6 +39,10 @@ namespace Building33MockApi
             builder.Services.AddGrpcSwagger();
             builder.Services.AddControllers();
             builder.Services.AddRazorPages();
+            builder.Services.AddHealthChecks()
+                .AddRedis(
+                connectionString,
+                name: "Redis");
 
             builder.Services.AddSwaggerGen(c =>
             {
@@ -65,6 +71,11 @@ namespace Building33MockApi
             app.MapGrpcReflectionService();
             app.MapRazorPages();
             app.MapControllers();
+            app.MapHealthChecks("/health", new HealthCheckOptions
+            {
+                Predicate = _ => true,
+                ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+            });
 
             app.Run();
         }


### PR DESCRIPTION
Fixes [AB#361](https://dev.azure.com/BritishLibrary-AppDev/f1fcc77c-6d52-4a59-849c-0a2a32895139/_workitems/edit/361)

Added health checks for the Building 33 Mock API and Redis cache